### PR TITLE
Remove inplace ops

### DIFF
--- a/mitxgraders/helpers/calc/expressions.py
+++ b/mitxgraders/helpers/calc/expressions.py
@@ -755,7 +755,7 @@ class MathExpression(object):
         """
         result = float(parse_result[0])
         if len(parse_result) == 2:
-            result *= suffixes[parse_result[1]]
+            result = result * suffixes[parse_result[1]]
         return result
 
     @staticmethod
@@ -1086,14 +1086,14 @@ class MathExpression(object):
             op = data.pop(0)
             value = data.pop(0)
             if op == '/':
-                result /= value
+                result = result/value
             elif op == '*':
                 if is_vector(value):
                     if double_vector_mult_has_occured:
                         raise triple_vector_mult_error
                     elif is_vector(result):
                         double_vector_mult_has_occured = True
-                result *= value
+                result = result*value
             else:
                 raise CalcError("Unexpected symbol {} in eval_product".format(op))
 
@@ -1132,9 +1132,9 @@ class MathExpression(object):
             op = data.pop(0)
             num = data.pop(0)
             if op == '+':
-                result += num
+                result = result + num
             elif op == '-':
-                result -= num
+                result = result - num
             else:
                 raise CalcError("Unexpected symbol {} in eval_sum".format(op))
         return result

--- a/mitxgraders/helpers/calc/math_array.py
+++ b/mitxgraders/helpers/calc/math_array.py
@@ -385,7 +385,8 @@ class MathArray(np.ndarray):
         raise TypeError("Cannot raise {type} to power of {self.shape_name}."
                         .format(type=type(other), self=self))
 
-    # in-place operations
+    # fake in-place operations
+    # they enable in-place syntax but return new objects
 
     def __iadd__(self, other):
         return self.__add__(other)


### PR DESCRIPTION
This PR removes numeric in-place operations from `expressions.py` (string `+=` ops are left in tact).

The motivation for this PR is a change in `numpy`'s behavior, illustrated below:

```
import numpy as np

A = np.array([1, 1, 1])

A *= 1.5; print(A)
# Numpy 1.6: array([1.5, 1.5, 1.5])
# Numpy 1.16: TypeError: Cannot cast ufunc multiply output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
```
Prior to numpy `1.10` (I believe), numpy was happy to re-cast arrays to arrays of a different type, in-place. 

This becomes a problem for us in situations like:
```python
import numpy as np
from mitxgraders.helpers.calc import evaluator

variables = {
    'A': np.array([1, 1, 1])
}
result, _ = evaluator('A/2', variables, {}, {})
# TypeError: ufunc 'true_divide' output (typecode 'd') could not be coerced to provided output parameter (typecode 'l') according to the casting rule ''same_kind''
```

# Maybe not necessary ... 
Really, people shouldn't be using `np.array`, they should be using our `MathArray`. It turns out that this change in numpy behavior is not a problem for `MathArray` since it's "in-place" operations (`__iadd__`, etc) are fake: they return new objects instead of modifying the original.

Still, this inconsistency in behavior makes me uncomfortable and I'd rather get rid of it. Maybe someone in the future will make `MathArray`'s `__iadd__` method truly in-place, or might find a reason to use numpy variables directly, or ... 

(Footnote: discoved while trying to fix test https://github.com/mitodl/mitx-grading-library/blob/32a66e19b1ea0b7939e0e88adc9edf4de6a3fe3c/tests/helpers/calc/test_expressions.py#L150)